### PR TITLE
[Feat] text-button 공통 컴포넌트 제작

### DIFF
--- a/public/svg/right-arrow.svg
+++ b/public/svg/right-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="5" height="7" viewBox="0 0 5 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L4 3.5L1 6" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svg/RightArrow.tsx
+++ b/src/assets/svg/RightArrow.tsx
@@ -1,0 +1,17 @@
+import type { SVGProps } from "react";
+const SvgRightArrow = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 5 7"
+    {...props}
+  >
+    <path
+      stroke="#000"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m1 1 3 2.5L1 6"
+    />
+  </svg>
+);
+export default SvgRightArrow;

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -1,0 +1,1 @@
+export { default as RightArrow } from "./RightArrow";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
-import TextButton from './shared/components/text-button/text-button.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-    <TextButton/>
   </StrictMode>,
 )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import TextButton from './shared/components/text-button/text-button.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
+    <TextButton/>
   </StrictMode>,
 )

--- a/src/shared/components/text-button/text-button.css.ts
+++ b/src/shared/components/text-button/text-button.css.ts
@@ -1,0 +1,16 @@
+import { style } from "@vanilla-extract/css";
+import { fontStyles } from "src/styles/tokens/font-styles.css";
+
+export const baseTextButtonContainer = style({
+	display: "flex",
+	justifyContent: "space-between",
+	minWidth: "86px",
+	alignItems: "center",
+	background: "none",
+	border: "none",
+	":hover": {
+		cursor: "pointer",
+	},
+	...fontStyles.caption_bold,
+	fontSize: "11px",
+});

--- a/src/shared/components/text-button/text-button.css.ts
+++ b/src/shared/components/text-button/text-button.css.ts
@@ -2,20 +2,20 @@ import { style } from "@vanilla-extract/css";
 import { fontStyles } from "src/styles/tokens/font-styles.css";
 
 export const baseTextButtonContainer = style({
-	display: "flex",
-	minWidth: "86px",
-	gap: "4px",
-	alignItems: "center",
-	background: "none",
-	border: "none",
-	":hover": {
-		cursor: "pointer",
-	},
+  display: "flex",
+  minWidth: "8.6rem",
+  gap: "0.4rem",
+  alignItems: "center",
+  background: "none",
+  border: "none",
+  ":hover": {
+    cursor: "pointer",
+  },
 });
 
 export const buttonText = style({
-	...fontStyles.caption_bold,
-	fontSize: "11px",
-	letterSpacing: "0px",
-	lineHeight: "100%",
+  ...fontStyles.caption_bold,
+  fontSize: "1.1rem",
+  letterSpacing: "0rem",
+  lineHeight: "100%",
 });

--- a/src/shared/components/text-button/text-button.css.ts
+++ b/src/shared/components/text-button/text-button.css.ts
@@ -4,7 +4,7 @@ import { fontStyles } from "src/styles/tokens/font-styles.css";
 export const baseTextButtonContainer = style({
 	display: "flex",
 	minWidth: "86px",
-    gap:'4px',
+	gap: "4px",
 	alignItems: "center",
 	background: "none",
 	border: "none",
@@ -14,8 +14,8 @@ export const baseTextButtonContainer = style({
 });
 
 export const buttonText = style({
-    ...fontStyles.caption_bold,
-  fontSize: "11px",
-  letterSpacing: "0px",
-  lineHeight: "100%",
-})
+	...fontStyles.caption_bold,
+	fontSize: "11px",
+	letterSpacing: "0px",
+	lineHeight: "100%",
+});

--- a/src/shared/components/text-button/text-button.css.ts
+++ b/src/shared/components/text-button/text-button.css.ts
@@ -3,14 +3,19 @@ import { fontStyles } from "src/styles/tokens/font-styles.css";
 
 export const baseTextButtonContainer = style({
 	display: "flex",
-	justifyContent: "space-between",
 	minWidth: "86px",
+    gap:'4px',
 	alignItems: "center",
 	background: "none",
 	border: "none",
 	":hover": {
 		cursor: "pointer",
 	},
-	...fontStyles.caption_bold,
-	fontSize: "11px",
 });
+
+export const buttonText = style({
+    ...fontStyles.caption_bold,
+  fontSize: "11px",
+  letterSpacing: "0px",
+  lineHeight: "100%",
+})

--- a/src/shared/components/text-button/text-button.css.ts
+++ b/src/shared/components/text-button/text-button.css.ts
@@ -17,5 +17,5 @@ export const buttonText = style({
   ...fontStyles.caption_bold,
   fontSize: "1.1rem",
   letterSpacing: "0rem",
-  lineHeight: "100%",
+  lineHeight: "150%",
 });

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -1,16 +1,18 @@
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { baseTextButtonContainer, buttonText } from "./text-button.css";
 import { RightArrow } from "src/assets/svg";
 
 interface TextButtonProps {
 	text?: string; // 버튼 내부에 작성할 문구
 	img?: ReactNode; // gap : 4 뒤에 렌더링할 요소(ex. 이미지)
+	onClick?: (event: MouseEvent<HTMLButtonElement>) => void; // 마우스 click시 이벤트
 }
 
 /**
  *
  * @param text 버튼 내부에 작성할 문구
  * @param img gap : 4 뒤에 렌더링할 요소(ex. 이미지)
+ * @param onClick void 반환 형식, 마우스 클릭했을 때 이벤트
  * @returns
  */
 const TextButton = ({

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -1,0 +1,19 @@
+// import type { ReactNode } from "react";
+
+import { baseTextButtonContainer } from "./text-button.css";
+
+interface TextButtonProps {
+	// text: string;
+	// img: ReactNode;
+}
+
+const TextButton = ({}: TextButtonProps) => {
+	return (
+		<button className={baseTextButtonContainer}>
+			<p>{`전체보기`}</p>
+			<p>{">"}</p>
+		</button>
+	);
+};
+
+export default TextButton;

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -1,11 +1,11 @@
 import type { MouseEvent, ReactNode } from "react";
-import { baseTextButtonContainer, buttonText } from "./text-button.css";
 import { RightArrow } from "src/assets/svg";
+import { baseTextButtonContainer, buttonText } from "./text-button.css";
 
 interface TextButtonProps {
-	text?: string; // 버튼 내부에 작성할 문구
-	img?: ReactNode; // gap : 4 뒤에 렌더링할 요소(ex. 이미지)
-	onClick?: (event: MouseEvent<HTMLButtonElement>) => void; // 마우스 click시 이벤트
+  text?: string; // 버튼 내부에 작성할 문구
+  img?: ReactNode; // gap : 4 뒤에 렌더링할 요소(ex. 이미지)
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void; // 마우스 click시 이벤트
 }
 
 /**
@@ -16,15 +16,15 @@ interface TextButtonProps {
  * @returns
  */
 const TextButton = ({
-	text = "전체보기",
-	img = <RightArrow width={5} height={5} />,
+  text = "전체보기",
+  img = <RightArrow width={"0.5rem"} height={"0.5rem"} />,
 }: TextButtonProps) => {
-	return (
-		<button className={baseTextButtonContainer}>
-			<span className={buttonText}>{text}</span>
-			{img}
-		</button>
-	);
+  return (
+    <button type="button" className={baseTextButtonContainer}>
+      <p className={buttonText}>{text}</p>
+      {img}
+    </button>
+  );
 };
 
 export default TextButton;

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -3,10 +3,16 @@ import { baseTextButtonContainer, buttonText } from "./text-button.css";
 import { RightArrow } from "src/assets/svg";
 
 interface TextButtonProps {
-	text?: string;
-	img?: ReactNode;
+	text?: string; // 버튼 내부에 작성할 문구
+	img?: ReactNode; // gap : 4 뒤에 렌더링할 요소(ex. 이미지)
 }
 
+/**
+ *
+ * @param text 버튼 내부에 작성할 문구
+ * @param img gap : 4 뒤에 렌더링할 요소(ex. 이미지)
+ * @returns
+ */
 const TextButton = ({
 	text = "전체보기",
 	img = <RightArrow width={5} height={5} />,

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -1,17 +1,17 @@
-// import type { ReactNode } from "react";
-
-import { baseTextButtonContainer } from "./text-button.css";
+import type { ReactNode } from "react";
+import { baseTextButtonContainer, buttonText } from "./text-button.css";
+import { RightArrow } from "src/assets/svg";
 
 interface TextButtonProps {
-	// text: string;
-	// img: ReactNode;
+	text?: string;
+	img?: ReactNode;
 }
 
-const TextButton = ({}: TextButtonProps) => {
+const TextButton = ({text='전체보기', img=<RightArrow width={5}height={5}/>}: TextButtonProps) => {
 	return (
 		<button className={baseTextButtonContainer}>
-			<p>{`전체보기`}</p>
-			<p>{">"}</p>
+			<span className={buttonText}>{text}</span>
+            {img}
 		</button>
 	);
 };

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -4,7 +4,7 @@ import { baseTextButtonContainer, buttonText } from "./text-button.css";
 
 interface TextButtonProps {
   text?: string; // 버튼 내부에 작성할 문구
-  img?: ReactNode; // gap : 4 뒤에 렌더링할 요소(ex. 이미지)
+  imageNode?: ReactNode; // gap : 4 뒤에 렌더링할 요소(ex. 이미지)
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void; // 마우스 click시 이벤트
 }
 
@@ -17,12 +17,12 @@ interface TextButtonProps {
  */
 const TextButton = ({
   text = "전체보기",
-  img = <RightArrow width={"0.5rem"} height={"0.5rem"} />,
+  imageNode = <RightArrow width={"0.5rem"} height={"0.5rem"} />,
 }: TextButtonProps) => {
   return (
     <button type="button" className={baseTextButtonContainer}>
       <p className={buttonText}>{text}</p>
-      {img}
+      {imageNode}
     </button>
   );
 };

--- a/src/shared/components/text-button/text-button.tsx
+++ b/src/shared/components/text-button/text-button.tsx
@@ -7,11 +7,14 @@ interface TextButtonProps {
 	img?: ReactNode;
 }
 
-const TextButton = ({text='전체보기', img=<RightArrow width={5}height={5}/>}: TextButtonProps) => {
+const TextButton = ({
+	text = "전체보기",
+	img = <RightArrow width={5} height={5} />,
+}: TextButtonProps) => {
 	return (
 		<button className={baseTextButtonContainer}>
 			<span className={buttonText}>{text}</span>
-            {img}
+			{img}
 		</button>
 	);
 };


### PR DESCRIPTION
## 📎 관련 이슈

<!-- 연결된 이슈가 있다면 기입 (#번호 형식) -->
- #20 

## 🔍 개요

<!-- 어떤 변경이 포함되었는지 간단히 설명해주세요. 의존성 설치 등 -->
- text-button 공통 컴포넌트 제작
- 의존성 설치 X

## 📌 주요 변경사항

-   [X] text button 공통 컴포넌트 제작
-   [X] text, 화살표 이미지 default 값 제공 후 원하는 값 입력할 수 있도록 제작

## 🎥 동작 스크린샷 / 영상

<!-- 동작 확인 가능한 이미지 또는 GIF 첨부. 필요시 설명 포함 -->

![image](https://github.com/user-attachments/assets/0eff0a21-9b18-4e9c-b54d-523a7ad7b71a)

## 🧪 테스트 방법

<!-- 테스트 방법, 확인 방법, 테스트 커버리지 등에 대해 적어주세요 -->
1. `<TextButton/>` 컴포넌트 호출
2. props에 text, img optional로 입력 가능

## 📝 상세 설명

<!-- 기능 세부사항, 의도한 동작, 고려사항 등 구체적으로 기술 -->
- figma 기준대로 적힌 letterSpacing이 적용이 안돼서 정렬 축 기준 정렬이 안돼었습니다
- lineHeight를 조정해서 정렬 축에 맞추긴 했는데 다른 해결방법 아시는 분 계신다면 공유해주세요!! 바로 해결하겠습니다.

## 📄 참고 자료

<!-- 참고한 문서나 링크가 있다면 기입 -->
